### PR TITLE
Change action-docker-layer-caching to new fork

### DIFF
--- a/initialize-cache/action.yaml
+++ b/initialize-cache/action.yaml
@@ -4,7 +4,7 @@ description: Initialize cache
 runs:
   using: "composite"
   steps:
-    - uses: satackey/action-docker-layer-caching@v0.0.11
+    - uses: jpribyl/action-docker-layer-caching@v0.1.1
     - run: docker rmi -f $(docker images | awk '$2 != "latest" && $2 != "testing" {print $3}') >/dev/null 2>&1 || exit 0
       shell: sh
     - run: docker builder prune -f


### PR DESCRIPTION
satackey/action-docker-layer-caching appears to be discontinued, a recent fork is jpribyl/action-docker-layer-caching.

I do not know if this will solve the build issue (for Sparwelt), but it is worth a try.